### PR TITLE
Fix conflict with legacy package.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   },
   "conflict": {
     "contao/core": "3.0.*",
-    "contao-legacy/htaccess": "*",
+    "contao-legacy/htaccess": "<3-dev",
     "bit3/contao-htaccess": "<3-dev"
   },
   "replace": {


### PR DESCRIPTION
The package bit3/contao-htaccess replaces contao-legacy/htaccess, so the conflict on contao-legacy/htaccess \* will also conflicts each version of bit3/contao-htaccess.
